### PR TITLE
fix: added missing sse parameter to glob pattern upload

### DIFF
--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -187,7 +187,7 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
         s"""
            |touch ${output.name}
            |$s3Cmd cp ${s3CmdEncryptionOptions} --no-progress ${output.name} ${output.s3key}
-           |if [ -e $globDirectory ]; then $s3Cmd cp --no-progress $globDirectory $s3GlobOutDirectory --recursive --exclude "cromwell_glob_control_file"; fi
+           |if [ -e $globDirectory ]; then $s3Cmd cp ${s3CmdEncryptionOptions} --no-progress $globDirectory $s3GlobOutDirectory --recursive --exclude "cromwell_glob_control_file"; fi
            |""".stripMargin
 
       case output: AwsBatchFileOutput if output.s3key.startsWith("s3://") && output.mount.mountPoint.pathAsString == AwsBatchWorkingDisk.MountPoint.pathAsString =>


### PR DESCRIPTION
This pr adds support for SSE for glob pattern parameters currently failing in GEL:

![image](https://user-images.githubusercontent.com/6191251/142901900-a6d5e8c2-6519-4c13-92a6-ebc4e569f456.png)
