### PR TITLE
fix: SSE for multipart upload

### DIFF
--- a/filesystems/s3/src/main/java/org/lerch/s3fs/S3FileSystemProvider.java
+++ b/filesystems/s3/src/main/java/org/lerch/s3fs/S3FileSystemProvider.java
@@ -505,7 +505,6 @@ public class S3FileSystemProvider extends FileSystemProvider {
                             .copySourceRange("bytes=" + finalBytePosition + "-" + lastByte)
                             .bucket(target.getFileStore().name())
                             .key(target.getKey())
-                            .serverSideEncryption(AES256.name())
                             .partNumber(finalPartNum)
                             .build();
                     UploadPartCopyResponse uploadPartCopyResponse =  s3Client.uploadPartCopy(uploadPartCopyRequest);

--- a/filesystems/s3/src/main/java/org/lerch/s3fs/S3FileSystemProvider.java
+++ b/filesystems/s3/src/main/java/org/lerch/s3fs/S3FileSystemProvider.java
@@ -505,7 +505,7 @@ public class S3FileSystemProvider extends FileSystemProvider {
                             .copySourceRange("bytes=" + finalBytePosition + "-" + lastByte)
                             .bucket(target.getFileStore().name())
                             .key(target.getKey())
-                            .sseCustomerAlgorithm(AES256.name())
+                            .serverSideEncryption(AES256.name())
                             .partNumber(finalPartNum)
                             .build();
                     UploadPartCopyResponse uploadPartCopyResponse =  s3Client.uploadPartCopy(uploadPartCopyRequest);


### PR DESCRIPTION
Here just removed the customer provider key property since multi part upload already has sse parameter here: http://github.com/lifebit-ai/cromwell/blob/d62e8e670c7c46ff74c1cff73d44bcaf1dac85f2/filesystems/s3/src/main/java/org/lerch/s3fs/S3FileSystemProvider.java#L469-L469