### PR TITLE
feat: supported intermediary optional outputs and added logging info for final output

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -399,6 +399,7 @@ class WorkflowActor(workflowToStart: WorkflowToStart,
     case Event(WorkflowFinalizationSucceededResponse, data) => finalizationSucceeded(data)
     case Event(WorkflowFinalizationFailedResponse(finalizationFailures), data) =>
       val failures = data.lastStateReached.failures.getOrElse(List.empty) ++ finalizationFailures
+      workflowLogger.warn(s"Workflow finalization failed. This may be caused for example by optional final outputs, which cromwell still does not support. Failures: ${finalizationFailures}")
       goto(WorkflowFailedState) using data.copy(lastStateReached = StateCheckpoint(FinalizingWorkflowState, Option(failures)))
     case Event(AbortWorkflowCommand, _) => stay()
   }

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -193,11 +193,11 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
       case output: AwsBatchFileOutput if output.s3key.startsWith("s3://") && output.mount.mountPoint.pathAsString == AwsBatchWorkingDisk.MountPoint.pathAsString =>
         //output is on working disk mount
         s"""
-           |$s3Cmd cp ${s3CmdEncryptionOptions} --no-progress $workDir/${output.local.pathAsString} ${output.s3key}
+           |if [ -f ${output.name} ]; then $s3Cmd cp ${s3CmdEncryptionOptions} --no-progress $workDir/${output.local.pathAsString} ${output.s3key}; else echo 'Output ${output.name} could not be created (and saved to results).'; fi
            |""".stripMargin
       case output: AwsBatchFileOutput =>
         //output on a different mount
-        s"$s3Cmd cp ${s3CmdEncryptionOptions} --no-progress ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString} ${output.s3key} "
+        s"if [ -f ${output.name} ]; then $s3Cmd cp ${s3CmdEncryptionOptions} --no-progress ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString} ${output.s3key}; else echo 'Output ${output.name} could not be created (and saved to results).'; fi "
       case _ => ""
     }.mkString("\n") + "\n" +
       s"""


### PR DESCRIPTION
relates to https://lifebit.atlassian.net/browse/AN-3223

It updates cromwell to avoid breaking batch job script when optional output exist at the process level and adds log to alert the user that optional outputs aren't supported for cromwell. However it saves existing outputs despite marking the job as failed state.