### PR TITLE
feat: added support for checking if optional outputs exist before copying to results

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -399,7 +399,6 @@ class WorkflowActor(workflowToStart: WorkflowToStart,
     case Event(WorkflowFinalizationSucceededResponse, data) => finalizationSucceeded(data)
     case Event(WorkflowFinalizationFailedResponse(finalizationFailures), data) =>
       val failures = data.lastStateReached.failures.getOrElse(List.empty) ++ finalizationFailures
-      workflowLogger.warn(s"Workflow finalization failed. This may be caused for example by optional final outputs, which cromwell still does not support. Failures: ${finalizationFailures}")
       goto(WorkflowFailedState) using data.copy(lastStateReached = StateCheckpoint(FinalizingWorkflowState, Option(failures)))
     case Event(AbortWorkflowCommand, _) => stay()
   }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
@@ -13,7 +13,8 @@ import cromwell.core.path.{Path, PathCopier, PathFactory}
 import cromwell.engine.EngineWorkflowDescriptor
 import cromwell.engine.backend.{BackendConfiguration, CromwellBackends}
 import cromwell.filesystems.gcs.batch.GcsBatchCommandBuilder
-import wom.values.{WomSingleFile, WomValue}
+import wom.values.{WomSingleFile, WomValue, WomOptionalValue}
+import wom.graph.GraphNodePort.OutputPort
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -48,12 +49,17 @@ class CopyWorkflowOutputsActor(workflowId: WorkflowId, override val ioActor: Act
 
   private def copyWorkflowOutputs(workflowOutputsFilePath: String): Future[Seq[Unit]] = {
     val workflowOutputsPath = buildPath(workflowOutputsFilePath)
-    val outputFilePaths = getOutputFilePaths(workflowOutputsPath)
+
+    val optionalOutputFiles = getOptionalOutputs()
+    val optionalOutputFilePaths = getOutputFilePaths(workflowOutputsPath, optionalOutputFiles)
+
+    val requiredOutputFiles = getRequiredOutputs()
+    val requiredOutputFilePaths = getOutputFilePaths(workflowOutputsPath, requiredOutputFiles)
 
     // Check if there are duplicated destination paths and throw an exception if that is the case.
     // This creates a map of destinations and source paths which point to them in cases where there are multiple
     // source paths that point to the same destination.
-    val duplicatedDestPaths: Map[Path, List[Path]] = outputFilePaths.groupBy{ case (_, destPath) => destPath}.collect {
+    val duplicatedDestPaths: Map[Path, List[Path]] = requiredOutputFilePaths.groupBy{ case (_, destPath) => destPath}.collect {
       case (destPath, list) if list.size > 1 => destPath -> list.map {case (source, _) => source}
     }
     if (duplicatedDestPaths.nonEmpty) {
@@ -67,11 +73,28 @@ class CopyWorkflowOutputsActor(workflowId: WorkflowId, override val ioActor: Act
         "Cannot copy output files to given final_workflow_outputs_dir" +
           s" as multiple files will be copied to the same path: \n${formattedCollidingCopyOptions.mkString("\n")}")}
 
-    val copies = outputFilePaths map {
+    val requiredCopies = requiredOutputFilePaths map {
       case (srcPath, dstPath) => asyncIo.copyAsync(srcPath, dstPath)
     }
+
+    val optionalCopies = optionalOutputFilePaths map {
+      case (srcPath, dstPath) => {
+        asyncIo.existsAsync(srcPath).flatMap(
+          result => {
+            if (result) {
+              asyncIo.copyAsync(srcPath, dstPath)
+            } else {
+              // NOTE: When a file does not exist when uploading we return an empty future to avoid throwing while copying.
+              Future.successful(())
+            }
+          }
+        )
+      }
+    }
+
+    val allCopies = requiredCopies ::: optionalCopies
     
-    Future.sequence(copies)
+    Future.sequence(allCopies)
   }
 
   private def findFiles(values: Seq[WomValue]): Seq[WomSingleFile] = {
@@ -81,8 +104,16 @@ class CopyWorkflowOutputsActor(workflowId: WorkflowId, override val ioActor: Act
       }
     }
   }
+
+  private def getRequiredOutputs(): Map[OutputPort, WomValue] = {
+    workflowOutputs.outputs.filter((keyVal) => !keyVal._2.isInstanceOf[WomOptionalValue])
+  }
+
+  private def getOptionalOutputs(): Map[OutputPort, WomValue] = {
+    workflowOutputs.outputs.filter((keyVal) => keyVal._2.isInstanceOf[WomOptionalValue])
+  }
   
-  private def getOutputFilePaths(workflowOutputsPath: Path): List[(Path, Path)] = {
+  private def getOutputFilePaths(workflowOutputsPath: Path, workflowOutputsToFilter: Map[OutputPort, WomValue]): List[(Path, Path)] = {
 
     val useRelativeOutputPaths: Boolean = workflowDescriptor.getWorkflowOption(UseRelativeOutputPaths).contains("true")
     val rootAndFiles = for {
@@ -90,7 +121,7 @@ class CopyWorkflowOutputsActor(workflowId: WorkflowId, override val ioActor: Act
       backend <- workflowDescriptor.backendAssignments.values.toSeq
       config <- BackendConfiguration.backendConfigurationDescriptor(backend).toOption.toSeq
       rootPath <- getBackendRootPath(backend, config).toSeq
-      outputFiles = findFiles(workflowOutputs.outputs.values.toSeq).map(_.value)
+      outputFiles = findFiles(workflowOutputsToFilter.values.toSeq).map(_.value)
     } yield (rootPath, outputFiles)
 
     // This regex will make sure the path is relative to the execution folder.


### PR DESCRIPTION
This PR introduces support for optional outputs in Cromwell source when saving results at the end of the workflow execution. Here we have introduced logic that ensures that a file that is optional output exists before trying to copy to the storage provider. Without doing this Cromwell was marking the workflow as failed: https://lifebit.atlassian.net/wiki/spaces/ARN/pages/115900494/AN-3222+1+Providing+access+to+Cromwell+logs+for+users+to+debug+WDL+pipelines+more+effectively#Known-issues